### PR TITLE
add possibility to turn off auto-escaping

### DIFF
--- a/src/filters.lisp
+++ b/src/filters.lisp
@@ -144,6 +144,10 @@
 (def-filter :safe (it)
   it)
 
+;;; this also
+(def-filter :escape (it)
+  it)
+
 ;;; TODO: Seems like an opportune place so adopt INTERACTIVE from Emacs.
 (def-filter :truncatechars (it n)
   (let ((n (if (stringp n)

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -7,6 +7,7 @@
         #:common-lisp
 	#:parser-combinators)
   (:export #:*allow-include-roots*
+           #:*auto-escape*
            #:*catch-template-errors-p*
 	   #:*verbose-errors-p*
 	   #:*fancy-error-template-p*

--- a/src/variables.lisp
+++ b/src/variables.lisp
@@ -1,5 +1,7 @@
 (in-package #:djula)
 
+(defvar *auto-escape* t)
+
 ;;; truncatechars:"30" => (:truncatechars 30)
 (defun parse-filter-string (string)
   (if-let ((colon (position #\: string)))
@@ -73,8 +75,12 @@ the result probably shouldn't be considered useful."
 
 (def-token-compiler :variable (variable-phrase &rest filters)
   ;; check to see if the "dont-escape" filter is used
+  ;; "safe" takes precedence before "escape"
   (let ((dont-escape
-         (find '(:safe) filters :test #'equal)))
+         (or
+          (find '(:safe) filters :test #'equal) ; safe filter used
+          (and (not *auto-escape*)              ; autoescape off and no escape filter used
+               (not (find '(:escape) filters :test #'equal))))))
     ;; return a function that resolves the variable-phase and applies the filters
     (lambda (stream)
       (multiple-value-bind (ret error-string)


### PR DESCRIPTION
I added `djula:*auto-escape*`, which controls auto escaping and is `t` by default.
Also, the filter `escape` is added to allow escaping with auto-escaping turned off.
Probably, this can be used to implement something like the `autoescape` tag as well.