### PR TITLE
Fix 'length' filter for lists.

### DIFF
--- a/src/filters.lisp
+++ b/src/filters.lisp
@@ -30,7 +30,9 @@
   (escape-for-html (princ-to-string it)))
 
 (def-filter :length (it)
-  (length (princ-to-string it)))
+  (length (if (typep it 'sequence)
+              it
+              (princ-to-string it))))
 
 (def-filter :sort (it &optional
 		      (predicate #'<)

--- a/test/filters.lisp
+++ b/test/filters.lisp
@@ -13,6 +13,7 @@
   (is (string= "short..." (filter :truncatechars "short message" 5)))
   (is (string= "UPPER"    (filter :upper "upper")))
   (is (=        6         (filter :length "length")))
+  (is (=        3         (filter :length '("abcd" "ef" "g"))))
   (is (string= "&lt;asdf&gt;" (filter :force-escape "<asdf>")))
   (is (string= "asdf<br />asdf" (filter :linebreaksbr "asdf
 asdf")))


### PR DESCRIPTION
'length' filter always converts an argument into a string and it's value is useless when it is a list.