### PR TITLE
Avoid calling CALL-NEXT-METHOD on a different object.

### DIFF
--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -71,11 +71,11 @@
 
 (defvar *current-compiler* (make-instance 'toplevel-compiler))
 
-(defmethod compile-template :around ((compiler toplevel-compiler) name &optional (error-p t))
+(defmethod compile-template ((compiler toplevel-compiler) name &optional (error-p t))
   (let ((*block-alist* nil)
         (*linked-files* nil))
     (let ((*current-compiler* (fragment-compiler compiler)))
-      (call-next-method))))
+      (compile-template *current-compiler* name error-p))))
 
 (defun compile-template* (name)
   "Compiles template NAME with compiler in *CURRENT-COMPILER*"


### PR DESCRIPTION
When the fragment compiler object is of a different class than the toplevel
compiler, this generates an error on SBCL: the arguments to CALL-NEXT-METHOD
are not permitted to change the applicable-methods list. Instead we'll just
use a normal call, which works with alternative compilers.

This was necessary to support new classes to store templates in-memory instead of on the filesystem.