### PR TITLE
Add *error-template*

### DIFF
--- a/src/conditions.lisp
+++ b/src/conditions.lisp
@@ -47,84 +47,10 @@
              (error ,e))))))
 
 (defun render-error-template (error backtrace &optional template stream)
-  (let ((error-template (djula::compile-string
-			 "<html>
-   <head>
-       <font face='arial'>
-       <style type='text/css'>
-           body {
-               margin: 0px;
-               background: #ececec;
-           }
-           #header {
-               padding-top:  5px;
-               padding-left: 25px;
-               color: white;
-               background: #a32306;
-               text-shadow: 1px 1px #33333;
-               border-bottom: 1px solid #710000;
-           }
-           #error-wrap {
-               border-top: 5px solid #d46e6b;
-           }
-           #error-message {
-               color: #800000;
-               background: #f5a29f;
-               padding: 10px;
-               text-shadow: 1px 1px #FFBBBB;
-               border-top: 1px solid #f4b1ae;
-           }
-           #file-wrap {
-               border-top: 5px solid #2a2a2a;
-           }
-           #file {
-               color: white;
-               background: #333333;
-               padding: 10px;
-               padding-left: 20px;
-               text-shadow: 1px 1px #555555;
-               border-top: 1px solid #444444;
-           }
-           #line-number {
-               width=20px;
-               color: #8b8b8b;
-               background: #d6d6d6;
-               float: left;
-               padding: 5px;
-               text-shadow: 1px 1px #EEEEEE;
-               border-right: 1px solid #b6b6b6;
-           }
-           #line-content {
-               float: left;
-               padding: 5px;
-           }
-           #error-content {
-               float: left;
-               width: 100%;
-               border-top: 5px solid #cdcdcd;
-               border-bottom: 5px solid #cdcdcd;
-           }
-       </style>
-   </head>
-   <body>
-       <div id='header'>
-           <h1>Template Compilation Error</h1>
-       </div>
-       <div id='error-wrap'>
-           <div id='error-message'>{{error}}.</div>
-       </div>
-       {% if template %}
-         <div id='file-wrap'>
-             <div id='file'>In {{template}}{% if line %} on line {{line}}{% endif %}.</div>
-         </div>
-         <div id='error-content'>
-           {{error-backtrace | linebreaksbr | safe }}
-         </div>
-       {% endif %}
-   </body>
-</html>
-")))
+  "Render the *ERROR-TEMPLATE* with the ERROR, the BACKTRACE and the TEMPLATE
+where the error ocurred."
+  (let ((error-template (compile-template* *error-template*)))
     (djula:render-template* error-template stream
-			    :error error
-			    :error-backtrace backtrace
-			    :template template)))
+                            :error error
+                            :error-backtrace backtrace
+                            :template template)))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -2,24 +2,25 @@
 
 (defpackage #:djula
   (:use #:iterate
-	#:alexandria
-	#:anaphora
+        #:alexandria
+        #:anaphora
         #:common-lisp
-	#:parser-combinators)
+        #:parser-combinators)
   (:export #:*allow-include-roots*
            #:*auto-escape*
            #:*catch-template-errors-p*
-	   #:*verbose-errors-p*
-	   #:*fancy-error-template-p*
-	   #:*fancy-debug-p*
+           #:*verbose-errors-p*
+           #:*fancy-error-template-p*
+           #:*fancy-debug-p*
            #:*current-compiler*
            #:*current-language*
            #:*current-store*
            #:*default-language*
+           #:*error-template*
            #:*template-eval*
            #:*template-root-folder*
            #:*template-search-path*
-	   #:*djula-execute-package*
+           #:*djula-execute-package*
            #:compile-template
            #:compile-template*
            #:compiler
@@ -35,6 +36,6 @@
            #:toplevel-compiler
            #:url-encode
            #:url-encode-path
-	   #:add-template-directory
-	   #:translate
-	   #:*translation-backend*))
+           #:add-template-directory
+           #:translate
+           #:*translation-backend*))

--- a/src/specials.lisp
+++ b/src/specials.lisp
@@ -25,3 +25,6 @@
 (defvar *current-block* nil)
 
 (defvar *linked-files*)
+
+(defvar *error-template* (asdf:system-relative-pathname :djula "templates/error-template.djhtml")
+  "The error template used by `render-error-template'.")

--- a/templates/error-template.djhtml
+++ b/templates/error-template.djhtml
@@ -1,0 +1,75 @@
+<html>
+  <head>
+    <font face='arial'>
+      <style type='text/css'>
+           body {
+               margin: 0px;
+               background: #ececec;
+           }
+           #header {
+               padding-top:  5px;
+               padding-left: 25px;
+               color: white;
+               background: #a32306;
+               text-shadow: 1px 1px #33333;
+               border-bottom: 1px solid #710000;
+           }
+           #error-wrap {
+               border-top: 5px solid #d46e6b;
+           }
+           #error-message {
+               color: #800000;
+               background: #f5a29f;
+               padding: 10px;
+               text-shadow: 1px 1px #FFBBBB;
+               border-top: 1px solid #f4b1ae;
+           }
+           #file-wrap {
+               border-top: 5px solid #2a2a2a;
+           }
+           #file {
+               color: white;
+               background: #333333;
+               padding: 10px;
+               padding-left: 20px;
+               text-shadow: 1px 1px #555555;
+               border-top: 1px solid #444444;
+           }
+           #line-number {
+               width=20px;
+               color: #8b8b8b;
+               background: #d6d6d6;
+               float: left;
+               padding: 5px;
+               text-shadow: 1px 1px #EEEEEE;
+               border-right: 1px solid #b6b6b6;
+           }
+           #line-content {
+               float: left;
+               padding: 5px;
+           }
+           #error-content {
+               float: left;
+               width: 100%;
+               border-top: 5px solid #cdcdcd;
+               border-bottom: 5px solid #cdcdcd;
+           }
+      </style>
+  </head>
+  <body>
+    <div id='header'>
+      <h1>Template Compilation Error</h1>
+    </div>
+    <div id='error-wrap'>
+      <div id='error-message'>{{error}}.</div>
+    </div>
+    {% if template %}
+      <div id='file-wrap'>
+        <div id='file'>In {{template}}{% if line %} on line {{line}}{% endif %}.</div>
+      </div>
+      <div id='error-content'>
+        {{error-backtrace | linebreaksbr | safe }}
+      </div>
+    {% endif %}
+  </body>
+</html>


### PR DESCRIPTION
So that the user can now customize the error template if he wishes. Also moved the default error template to a file instead of a string to ease future editing.