### PR TITLE
Lexer now builds list in the right order

### DIFF
--- a/djula.asd
+++ b/djula.asd
@@ -26,7 +26,7 @@
             ((:file "compiler"       :depends-on ("lexer" "parser" "template-store"))
              (:file "conditions"     :depends-on ("specials"))
              (:file "filters"        :depends-on ("pipeline"))
-             (:file "lexer"          :depends-on ("pipeline"))
+             (:file "lexer"          :depends-on ("pipeline" "util"))
              (:file "packages")
              (:file "parser"         :depends-on ("pipeline"))
              (:file "pipeline"       :depends-on ("conditions"))

--- a/src/lexer.lisp
+++ b/src/lexer.lisp
@@ -57,20 +57,19 @@ Although not a lexer token, the keyword :not-special is used to signify that the
 
 (defun parse-template-string (template)
   "Transform the TEMPLATE into a list of lexer tokens "
-  (let ((results nil)
-        (current-position 0))
-    (loop
-      :for { := (next-tag template current-position)
-      :until (null {)
-      :do
-         (when (> { current-position)
-           (push `(:string ,(subseq template current-position {)) results))
-         (multiple-value-bind (token next-position) (parse-tag template {)
-           (push token results)
-           (setf current-position next-position)))
-    (when (< current-position (length template))
-      (push `(:string ,(subseq template current-position)) results))
-    (nreverse results)))
+  (let ((current-position 0))
+    (accum accumulate
+      (loop
+        :for { := (next-tag template current-position)
+        :until (null {)
+        :do
+           (when (> { current-position)
+             (accumulate `(:string ,(subseq template current-position {))))
+           (multiple-value-bind (token next-position) (parse-tag template {)
+             (accumulate token)
+             (setf current-position next-position)))
+      (when (< current-position (length template))
+        (accumulate `(:string ,(subseq template current-position)))))))
 
 (def-token-compiler :verbatim (string)
   (lambda (stream)

--- a/src/lexer.lisp
+++ b/src/lexer.lisp
@@ -55,9 +55,10 @@ Although not a lexer token, the keyword :not-special is used to signify that the
       (:not-special (values '(:string "{")
                             (1+ current-position))))))
 
-(defun split-template-string (template current-position)
+(defun parse-template-string (template)
   "Transform the TEMPLATE into a list of lexer tokens "
-  (let (results)
+  (let ((results nil)
+        (current-position 0))
     (loop
       :for { := (next-tag template current-position)
       :until (null {)
@@ -74,6 +75,3 @@ Although not a lexer token, the keyword :not-special is used to signify that the
 (def-token-compiler :verbatim (string)
   (lambda (stream)
     (write-string string stream)))
-
-(defun parse-template-string (string)
-  (split-template-string string 0))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -75,3 +75,17 @@ STRING unmodified. If the truncation is impossible to accomplish, return nil. "
                     (subseq string 0 (- max-length elision-string-length))
                     elision-string))
       (t string))))
+
+;; Taken from: http://malisper.me/2015/05/31/efficiently-building-lists/
+(defmacro accum (accfn &body body)
+  (let ((ghead (gensym "HEAD"))
+        (gtail (gensym "TAIL"))
+        (garg  (gensym "ARG")))
+    `(let* ((,ghead (list nil))
+            (,gtail ,ghead))
+       (macrolet ((,accfn (,garg)
+                    `(setf ,',gtail
+                           (setf (cdr ,',gtail)
+                                 (list ,,garg)))))
+         ,@body
+         (cdr ,ghead)))))


### PR DESCRIPTION
A small improvement in the lexer, build the list in the right order from the start avoiding the need to reverse the list at the end. I'm including code from @malisper's blog. I can't find a license for the snippets in his blog so maybe we should wait for his explicit permission? 