### PR TITLE
Move pipeline functions to packages

### DIFF
--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -115,7 +115,7 @@
 
 (defun compile-token (token)
   (destructuring-bind (name . args) token
-    (let ((compiler (get name 'token-compiler)))
+    (let ((compiler (find-token-compiler name)))
       (if (null compiler)
           (lambda (stream)
             (princ (template-error-string "Unknown token ~A" name) stream))

--- a/src/filters.lisp
+++ b/src/filters.lisp
@@ -5,7 +5,7 @@
             (destructuring-bind (name . args)
                 filter
               (handler-case
-                  (if-let ((fn (get name 'filter)))
+                  (if-let ((fn (find-filter name)))
                     (apply fn value args)
                     (template-error-string "Unknown filter ~A" name))
                 (template-error (e1)

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -44,6 +44,7 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (unless (find-package "DJULA.TOKEN-PROCESSORS")
     (defpackage "DJULA.TOKEN-PROCESSORS"
+      (:use)
       (:documentation "Contains the token processors")
       (:export #:comment-tag
                #:almost-parsed-ifequal
@@ -59,6 +60,7 @@
 
   (unless (find-package "DJULA.UNPARSED-TAG-PROCESSORS")
     (defpackage "DJULA.UNPARSED-TAG-PROCESSORS"
+      (:use)
       (:documentation "This package contains the unparsed tag processors.")
       (:export #:filter
                #:set
@@ -70,6 +72,7 @@
 
   (unless (find-package "DJULA.TAG-PROCESSORS")
     (defpackage "DJULA.TAG-PROCESSORS"
+      (:use)
       (:documentation "This package contains the tag processors.")
       (:export #:semi-parsed-ifequal
                #:semi-parsed-filter
@@ -85,6 +88,7 @@
 
   (unless (find-package "DJULA.TOKEN-COMPILERS")
     (defpackage "DJULA.TOKEN-COMPILERS"
+      (:use)
       (:documentation "This package contains the token compilers.")
       (:export #:parsed-js-script
                #:tag
@@ -105,6 +109,7 @@
 
   (unless (find-package "DJULA.TAG-COMPILERS")
     (defpackage "DJULA.TAG-COMPILERS"
+      (:use)
       (:documentation "This package contains the tag compilers.")
       (:export #:set-package
                #:endifchanged
@@ -129,6 +134,7 @@
 
   (unless (find-package "DJULA.FILTERS")
     (defpackage "DJULA.FILTERS"
+      (:use)
       (:documentation "This package contains the djula filters. Filters are take as
   a first argument a string and return a string.")
       (:export #:date

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -40,3 +40,122 @@
            #:add-template-directory
            #:translate
            #:*translation-backend*))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (unless (find-package "DJULA.TOKEN-PROCESSORS")
+    (defpackage "DJULA.TOKEN-PROCESSORS"
+      (:documentation "Contains the token processors")
+      (:export #:comment-tag
+               #:almost-parsed-ifequal
+               #:almost-parsed-ifnotequal
+               #:comment
+               #:unparsed-variable
+               #:semi-parsed-js-script
+               #:unparsed-translation-variable
+               #:tag
+               #:semi-parsed-if
+               #:string
+               #:unparsed-tag)))
+
+  (unless (find-package "DJULA.UNPARSED-TAG-PROCESSORS")
+    (defpackage "DJULA.UNPARSED-TAG-PROCESSORS"
+      (:documentation "This package contains the unparsed tag processors.")
+      (:export #:filter
+               #:set
+               #:trans
+               #:lisp
+               #:ifequal
+               #:ifnotequal
+               #:js)))
+
+  (unless (find-package "DJULA.TAG-PROCESSORS")
+    (defpackage "DJULA.TAG-PROCESSORS"
+      (:documentation "This package contains the tag processors.")
+      (:export #:semi-parsed-ifequal
+               #:semi-parsed-filter
+               #:js-script
+               #:comment
+               #:block
+               #:autoescape
+               #:for
+               #:ifchanged
+               #:if
+               #:semi-parsed-ifnotequal
+               #:extends)))
+
+  (unless (find-package "DJULA.TOKEN-COMPILERS")
+    (defpackage "DJULA.TOKEN-COMPILERS"
+      (:documentation "This package contains the token compilers.")
+      (:export #:parsed-js-script
+               #:tag
+               #:string
+               #:parsed-filter
+               #:verbatim
+               #:translation-variable
+               #:parsed-if
+               #:parsed-block
+               #:parsed-js
+               #:parsed-ifchanged
+               #:parsed-ifequal
+               #:parsed-lisp
+               #:variable
+               #:parsed-autoescape
+               #:parsed-set
+               #:parsed-for)))
+
+  (unless (find-package "DJULA.TAG-COMPILERS")
+    (defpackage "DJULA.TAG-COMPILERS"
+      (:documentation "This package contains the tag compilers.")
+      (:export #:set-package
+               #:endifchanged
+               #:show-language
+               #:endautoescape
+               #:endifnotequal
+               #:cycle
+               #:endcomment
+               #:endfor
+               #:set-language
+               #:emit-js
+               #:endifequal
+               #:templatetag
+               #:endjs-script
+               #:super
+               #:ssi
+               #:endblock
+               #:endfilter
+               #:endif
+               #:include
+               #:debug)))
+
+  (unless (find-package "DJULA.FILTERS")
+    (defpackage "DJULA.FILTERS"
+      (:documentation "This package contains the djula filters. Filters are take as
+  a first argument a string and return a string.")
+      (:export #:date
+               #:force-escape
+               #:datetime
+               #:trans
+               #:safe
+               #:escape
+               #:linebreaksbr
+               #:last
+               #:truncatechars
+               #:addslashes
+               #:time
+               #:lisp
+               #:capfirst
+               #:urlencode
+               #:sort
+               #:linebreaks
+               #:length
+               #:upper
+               #:slice
+               #:lower
+               #:format
+               #:first
+               #:cut
+               #:add
+               #:default
+               #:reverse
+               #:join))))
+

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -2,28 +2,32 @@
 
 (defun process-token (token rest-token-list)
   (destructuring-bind (name . args) token
-    (let ((f (get name 'token-processor)))
+    (let ((f (find-token-processor name)))
       (if (null f)
-	  ;; If it is not a processor, then just collect the token
-	  (cons token (process-tokens rest-token-list))
-	  ;; else, we apply the processor
-	  (progn
+          ;; XXX: Move this to find-token-processor, as the 'default' token
+          ;; processor.
+          ;; If it is not a processor, then just collect the token
+          (cons token (process-tokens rest-token-list))
+          ;; else, we apply the processor
+          (progn
             (handler-case
                 (apply f rest-token-list args)
               (template-error (e1)
-                ;; Parse errors can be reported by substituting a simple string token.
+                ;; Parse errors can be reported by substituting a simple string
+                ;; token.
                 (if (and *catch-template-errors-p*
-			 (not *fancy-error-template-p*))
+                         (not *fancy-error-template-p*))
                     (cons
                      (list :string
                            (princ-to-string e1))
                      (process-tokens rest-token-list))
                     (error e1)))
               (error (e2)
-                ;; Parse errors can be reported by substituting a simple string token.
-                (let ((msg (template-error-string* e2"There was an error processing the token ~A" token)))
+                ;; Parse errors can be reported by substituting a simple string
+                ;; token.
+                (let ((msg (template-error-string* e2 "There was an error processing the token ~A" token)))
                   (if (and *catch-template-errors-p*
-			   (not *fancy-error-template-p*))
+                           (not *fancy-error-template-p*))
                       (cons
                        (list :string
                              msg)

--- a/test/filters.lisp
+++ b/test/filters.lisp
@@ -3,7 +3,7 @@
 (in-suite djula-test)
 
 (defun filter (name &rest args)
-  (apply (get name 'djula::filter) args))
+  (apply (djula::find-filter name) args))
 
 (def-test filters (:compile-at :definition-time)
   (is (string= "Capfirst" (filter :capfirst "capfirst")))

--- a/test/tags.lisp
+++ b/test/tags.lisp
@@ -211,13 +211,15 @@
     (is (equalp
          (djula:render-template* template nil :list (make-hash-table))
          "<ul></ul>"))
-    (is (equalp
+    (is (member
          (djula:render-template* template nil
                                  :list (let ((table (make-hash-table)))
                                          (setf (gethash 'b table) 'bar)
                                          (setf (gethash 'a table) 'foo)
                                          table))
-         "<ul><li>A->FOO</li><li>B->BAR</li></ul>"))))
+         '("<ul><li>A->FOO</li><li>B->BAR</li></ul>"
+           "<ul><li>B->BAR</li><li>A->FOO</li></ul>")
+         :test #'string=))))
 
 (def-test nested-loop-test (:compile-at :definition-time)
   (let ((template (djula::compile-string "{% for list in lists %}<ul>{% for elem in list %}<li>{{elem}}</li>{% endfor %}</ul>{% endfor %}")))

--- a/test/tags.lisp
+++ b/test/tags.lisp
@@ -3,8 +3,8 @@
 (in-suite djula-test)
 
 (defun tag (name &rest args)
-  (let ((fn (apply (or (get name 'djula::tag-compiler)
-                       (get name 'djula::token-compiler))
+  (let ((fn (apply (or (djula::find-tag-compiler name)
+                       (djula::find-token-compiler name))
                    args))
         (*template-arguments* nil))
     (with-output-to-string (s)
@@ -12,7 +12,7 @@
 
 (def-test cycle (:compile-at :definition-time)
   (is (string= "010101"
-               (let ((fn (apply (get :cycle 'djula::tag-compiler) '(0 1)))
+               (let ((fn (apply (djula::find-tag-compiler :cycle) '(0 1)))
                      (djula::*template-arguments* nil))
                  (with-output-to-string (s)
                    (dotimes (_ 6)


### PR DESCRIPTION
This helps when developing and debugging the code as one may now trace the functions in the pipeline.
 
The eval-when in the packages is due to the following. When the export list does not coincide with the exported symbols a warning is signal and compilation fails. And when running test-system if the files have change ASDF tries to recompile the system.