### PR TITLE
More filters doc

### DIFF
--- a/doc/source/filters.rst
+++ b/doc/source/filters.rst
@@ -1029,11 +1029,11 @@ Custom filters
 
 Use the ``def-filter`` macro. Its general form is::
 
-        (def-filter :myfilter-name (value arg2 &optional other-args)
+        (def-filter :myfilter-name (value arg)
            (body))
 
-It always takes the variable's value as argument, and it can have more
-required or optional arguments. For example, this is how those
+It always takes the variable's value as argument, and it can have one
+required or optional argument. For example, this is how those
 built-in filters are defined::
 
        (def-filter :capfirst (val)
@@ -1052,6 +1052,21 @@ and with an optional one::
 
        (def-filter :datetime (it &optional format)
          (let ((timestamp …))))
+
+When you need to pass a second argument, make your filter return a
+lambda function and chain it with the ``with`` filter::
+
+    (def-filter :replace (it regex)
+       (lambda (replace)
+         (ppcre:regex-replace-all regex it replace)))
+
+    (def-filter :with (it replace)
+       (funcall it replace))
+
+Now we can write::
+
+    {{ value | replace:foo | with:bar }}
+
 
 Errors are handled by the macro, but you can handle them and return a
 ``template-error`` condition::

--- a/doc/source/filters.rst
+++ b/doc/source/filters.rst
@@ -156,16 +156,7 @@ If ``value`` is ``""`` (the empty string), the output will be ``nothing``.
 
 .. templatefilter:: default_if_none
 
-.. templatefilter:: sort
-
-sort
-^^^^
-
-Takes a list and returns that list sorted.
-
-For example::
-
-    {{ list | sort }}
+.. templatefilter:: reverse
 
 reverse
 ^^^^^^^
@@ -174,7 +165,7 @@ Takes a list and returns that list reversed.
 
 For example::
 
-    {{ list | reverse }}  
+    {{ list | reverse }}
 
 ..
    divisibleby
@@ -189,7 +180,20 @@ For example::
    If ``value`` is ``21``, the output would be ``True``.
 
 ..
-   .. templatefilter:: escape
+
+.. templatefilter:: sort
+
+sort
+^^^^
+
+Takes a list and returns that list sorted.
+
+For example::
+
+    {{ list | sort }}
+
+
+.. templatefilter:: escape
 
    escape
    ^^^^^^
@@ -396,6 +400,7 @@ slug``.
 
    If ``value`` is ``Djula``, the output will be ``"Djula    "``.
 
+
 .. templatefilter:: lower
 
 lower
@@ -532,8 +537,8 @@ If ``value`` is ``Still MAD At Yoko``, the output will be
 
 .. templatefilter:: safe
 
-safe
-^^^^
+safe, escape
+^^^^^^^^^^^^
 
 Marks a string as not requiring further HTML escaping prior to output. When
 autoescaping is off, this filter has no effect.
@@ -580,14 +585,14 @@ Syntax::
 Each ``slice`` selects a subset of subscripts along the corresponding axis.
 
 * A nonnegative integer selects the corresponding index, while a negative integer selects an index counting backwards from the last index::
-    
+
   {{ list | slice: 4 }}
 
 if the list is ``(1 2 3 4 5 6)`` it will output ``(5)``
 
 * ``(start . end)`` to select a range.  When ``end`` is ``NIL``, the last index is included.
 Each boundary is resolved according to the other rules if applicable, so you can use negative integers::
-    
+
   {{ string | slice: (0 . 5) }}
   {{ string | slice: (5 . nil) }}
 
@@ -608,6 +613,18 @@ if the string is ``"Hello world"`` is will output ``Hello`` and ``world``.
        {{ value|slugify }}
 
    If ``value`` is ``"Joel is a slug"``, the output will be ``"joel-is-a-slug"``.
+
+.. templatefilter:: force-escape
+
+force-escape
+^^^^^^^^^^^^
+
+Forces escaping HTML characters (``<, >, ', \, &``)::
+
+
+       {{ value | force-escape }}
+
+It calls ``djula::escape-for-html``.
 
 .. templatefilter:: format
 
@@ -648,7 +665,30 @@ If ``value`` is ``1000000``, the output will be ``1,000,000``.
 
    .. _clean: http://bleach.readthedocs.org/en/latest/clean.html
 
-   .. templatefilter:: time
+   .. templatefilter:: replace
+
+replace ... with
+^^^^^^^^^^^^^^^^
+
+The ``replace`` and the ``with`` filters work together::
+
+    {{ value | replace:regexp | with:string }}
+
+This will replace all occurences of the regexp in "value" with a new
+string, using ``ppcre:regex-replace-all``.
+
+.. templatefilter:: scan
+
+scan
+^^^^
+
+Extracts and displays a regexp from the value::
+
+    {{ value | scan:regexp }}
+
+This will display only the text that matches the regexp (using ``ppcre:scan-to-strings``).
+
+.. templatefilter:: time
 
 time
 ^^^^

--- a/src/filters.lisp
+++ b/src/filters.lisp
@@ -61,6 +61,7 @@
 (def-filter :linebreaksbr (it)
   (cl-ppcre:regex-replace-all "\\n" (princ-to-string it) "<br />"))
 
+;xxx: undocumented
 (def-filter :lisp (it &optional lisp-string)
   (unless *eval-lisp-tags*
     (template-error "I can't evaulate the \"lisp\" filter ~A because *EVAL-LISP-TAGS* is NIL" lisp-string))


### PR DESCRIPTION
Hi,

I documented missing filters, except the lisp one,

and corrected myself: creating a filter with two arguments throws an error (correct me if I'm wrong), so we can chain our filter with `with`, as does replace: `replace:regexp | with:bar`.