### PR TITLE
fix truncatechars filter with a string smaller than the ellision

### DIFF
--- a/src/util.lisp
+++ b/src/util.lisp
@@ -69,6 +69,8 @@ STRING unmodified. If the truncation is impossible to accomplish, return nil. "
   (let ((string-length (length string))
         (elision-string-length (length elision-string)))
     (cond
+      ((< string-length max-length)
+       string)
       ((> elision-string-length string-length)
        nil)
       ((> string-length max-length)


### PR DESCRIPTION
The cond missed a branch!

Previously, trying to truncate a string of 2 characters returned nil,
because it is shorter than "...",
and thus an error message in the template.

Now a string that is shorter than the max length is returned as is.