### PR TITLE
specials.lisp: initialize *template-arguments* (and 2 more) to nil

### DIFF
--- a/src/specials.lisp
+++ b/src/specials.lisp
@@ -1,6 +1,6 @@
 (in-package #:djula)
 
-(defvar *template-arguments*)
+(defvar *template-arguments* nil)
 
 (defvar *current-language* nil)
 
@@ -24,9 +24,9 @@
 
 (defvar *current-block* nil)
 
-(defvar *linked-templates*)
+(defvar *linked-templates* nil)
 
-(defvar *current-template*)
+(defvar *current-template* nil)
 
 (defvar *error-template* (asdf:system-relative-pathname :djula "templates/error-template.djhtml")
   "The error template used by `render-error-template'.")


### PR DESCRIPTION
so we don't have an "UNBOUND variable error" when we try

(setf (getf djula::*template-arguments* :foo) "bar)

as seen in #33