### PR TITLE
Remove dependency on 'anaphora'

### DIFF
--- a/djula.asd
+++ b/djula.asd
@@ -11,7 +11,6 @@
      (uiop:subpathname *load-pathname* "README.md"))
   :depends-on (#:access
                #:alexandria
-               #:anaphora
                #:babel
                #:cl-ppcre
                #:split-sequence

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -3,7 +3,6 @@
 (defpackage #:djula
   (:use #:iterate
         #:alexandria
-        #:anaphora
         #:common-lisp
         #:parser-combinators)
   (:export #:*allow-include-roots*

--- a/src/variables.lisp
+++ b/src/variables.lisp
@@ -97,8 +97,8 @@ is a direct translation from the dot (.) syntax] and returns two values:
    1. the result [looking up the var and applying index/keys]
    2. an error string if something went wrond [note: if there is an error string then
 the result probably shouldn't be considered useful."
-  (aand (get-variable (first list))
-        (apply-keys/indexes it (rest list))))
+  (when-let (v (get-variable (first list)))
+    (apply-keys/indexes v (rest list))))
 
 (def-token-compiler :variable (variable-phrase &rest filters)
   ;; check to see if the "dont-escape" filter is used


### PR DESCRIPTION
It's only used in three places, and all of them can be rewritten
using IF-LET, WHEN-LET from alexandria without making the code
any longer.